### PR TITLE
task: disable ui tests until the backend can serve the latest version of the UI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,3 +11,9 @@ jobs:
     uses: ./.github/workflows/global-ci.yml
     with:
       operator_bundle: "ghcr.io/trustification/trustify-operator-bundle:latest"
+      # TODO
+      # We run this against ghcr.io/trustification/trustd:latest which does not contain the
+      # latest version of the UI. Therefore the UI tests will always fail.
+      # The repository https://github.com/trustification/trustify needs to find a way to continuously
+      # update the UI before this property is enabled
+      run_ui_tests: false

--- a/.github/workflows/nightly-main.yaml
+++ b/.github/workflows/nightly-main.yaml
@@ -13,4 +13,9 @@ jobs:
       api_tests_ref: main
       run_api_tests: true
       ui_tests_ref: main
-      run_ui_tests: true
+      # TODO
+      # We run this against ghcr.io/trustification/trustd:latest which does not contain the
+      # latest version of the UI. Therefore the UI tests will always fail.
+      # The repository https://github.com/trustification/trustify needs to find a way to continuously
+      # update the UI before this property is enabled
+      run_ui_tests: false


### PR DESCRIPTION
Another idea is to make the operator to instantiate the UI in a separate container. That would allow the operator to point to the latest container version of the UI (which is created by every commit)